### PR TITLE
新增自动漫游开关

### DIFF
--- a/client/src/api/music/fmMode.ts
+++ b/client/src/api/music/fmMode.ts
@@ -1,5 +1,8 @@
 export const DEFAULT_FM_MODE = 'DEFAULT';
 
+/** 关闭漫游：队列放空后停止播放，不自动推荐（不作为列表选项展示） */
+export const FM_MODE_OFF = 'OFF';
+
 export interface FmModeOption {
   value: string;
   label: string;
@@ -16,9 +19,12 @@ export const NETEASE_FM_MODE_OPTIONS: FmModeOption[] = [
   { value: 'aidj', label: 'AI DJ', description: 'AI 串烧混剪，曲间带过渡衔接' },
 ];
 
-const FM_MODE_VALUES = new Set(NETEASE_FM_MODE_OPTIONS.map((o) => o.value));
+const FM_MODE_VALUES = new Set([...NETEASE_FM_MODE_OPTIONS.map((o) => o.value), FM_MODE_OFF]);
 
-const FM_MODE_LABEL_MAP = new Map(NETEASE_FM_MODE_OPTIONS.map((o) => [o.value, o.label]));
+const FM_MODE_LABEL_MAP = new Map([
+  ...NETEASE_FM_MODE_OPTIONS.map((o) => [o.value, o.label] as [string, string]),
+  [FM_MODE_OFF, '已关闭'] as [string, string],
+]);
 
 export function normalizeFmMode(input: string | null | undefined): string {
   const raw = String(input || '').trim();

--- a/client/src/components/RoomSettingsModal.tsx
+++ b/client/src/components/RoomSettingsModal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Minus, Plus, Sparkles, X } from 'lucide-react';
-import { NETEASE_FM_MODE_OPTIONS, getFmModeLabel, normalizeFmMode } from '../api/music/fmMode';
+import { NETEASE_FM_MODE_OPTIONS, getFmModeLabel, normalizeFmMode, FM_MODE_OFF, DEFAULT_FM_MODE } from '../api/music/fmMode';
 import type { BannedSong } from '../types';
 import type { DislikeSkipMode } from '../lib/dislikeSkip';
 import SourceBadge from './SourceBadge';
@@ -53,6 +53,7 @@ interface Props {
   isOwner: boolean;
   canModerate: boolean;
   fmMode: string;
+  fmModeBeforeOff?: string;
   fmSaving?: boolean;
   announcementEnabled: boolean;
   announcementText: string;
@@ -184,6 +185,7 @@ export default function RoomSettingsModal({
   isOwner,
   canModerate,
   fmMode,
+  fmModeBeforeOff,
   fmSaving = false,
   announcementEnabled,
   announcementText,
@@ -350,15 +352,22 @@ export default function RoomSettingsModal({
         <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
           {activeTab === 'fm' && isOwner && (
             <section>
-              <p className="mb-3 text-xs text-netease-muted">
-                队列为空时通过私人漫游自动推荐下一首
-              </p>
-              <div className="space-y-1.5">
+              <Toggle
+                checked={currentFm !== FM_MODE_OFF}
+                disabled={fmSaving}
+                onChange={(next) => {
+                  const restored = normalizeFmMode(fmModeBeforeOff);
+                  onSaveFmMode(next ? (restored === FM_MODE_OFF ? DEFAULT_FM_MODE : restored) : FM_MODE_OFF);
+                }}
+                label="自动漫游"
+                description="队列为空时通过私人漫游自动推荐下一首"
+              />
+              <div className={`mt-3 space-y-1.5 ${currentFm === FM_MODE_OFF ? 'opacity-40' : ''}`}>
                 {NETEASE_FM_MODE_OPTIONS.map((opt) => (
                   <button
                     key={opt.value}
                     type="button"
-                    disabled={fmSaving}
+                    disabled={fmSaving || currentFm === FM_MODE_OFF}
                     onClick={() => onSaveFmMode(opt.value)}
                     className={`w-full rounded-xl border px-3 py-2 text-left transition-colors disabled:opacity-50 ${
                       currentFm === opt.value

--- a/client/src/pages/Room.tsx
+++ b/client/src/pages/Room.tsx
@@ -2038,6 +2038,7 @@ export default function Room() {
         isOwner={isOwner}
         canModerate={canModerate}
         fmMode={normalizeFmMode(room?.neteaseFmMode)}
+        fmModeBeforeOff={room?.fmModeBeforeOff}
         fmSaving={fmSaving}
         announcementEnabled={Boolean(room?.announcementEnabled)}
         announcementText={room?.announcementText || ''}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -173,6 +173,8 @@ export interface RoomState {
   audioQuality?: RoomAudioQuality;
   /** 队列为空时私人漫游推荐模式 */
   neteaseFmMode?: string;
+  /** 漫游关闭前的模式，重新开启时恢复 */
+  fmModeBeforeOff?: string;
   /** 公告是否开启 */
   announcementEnabled?: boolean;
   /** 公告内容 */

--- a/server/metingFm.js
+++ b/server/metingFm.js
@@ -5,6 +5,9 @@ const METING_API_AUTH = process.env.METING_API_AUTH || '';
 
 export const DEFAULT_FM_MODE = 'DEFAULT';
 
+/** 关闭漫游：队列放空后停止播放，不自动推荐 */
+export const FM_MODE_OFF = 'OFF';
+
 const FM_MODES = new Set([
   'DEFAULT',
   'FAMILIAR',
@@ -14,6 +17,7 @@ const FM_MODES = new Set([
   'SCENE_RCMD:EXERCISE',
   'SCENE_RCMD:FOCUS',
   'SCENE_RCMD:NIGHT_EMO',
+  FM_MODE_OFF,
 ]);
 
 async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
@@ -78,6 +82,7 @@ const MAX_FM_RETRIES = 5;
 
 /** 网易云私人漫游（Meting type=fm） */
 export async function fetchMetingFmSong(fmMode = DEFAULT_FM_MODE) {
+  if (normalizeFmMode(fmMode) === FM_MODE_OFF) return null;
   for (let i = 0; i < MAX_FM_RETRIES; i += 1) {
     try {
       const response = await fetchWithTimeout(buildFmUrl(fmMode));

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -1,6 +1,6 @@
 import { customAlphabet } from 'nanoid';
 import { scryptSync, randomBytes, timingSafeEqual } from 'crypto';
-import { fetchMetingFmSong, normalizeFmMode, DEFAULT_FM_MODE } from './metingFm.js';
+import { fetchMetingFmSong, normalizeFmMode, DEFAULT_FM_MODE, FM_MODE_OFF } from './metingFm.js';
 import {
   initRoomStorage,
   isRedisEnabled,
@@ -204,6 +204,7 @@ function snapshotRoomForStorage(room) {
     userNicknames: Object.fromEntries(room.userNicknames || []),
     audioQuality: room.audioQuality ?? { netease: 'hires', tencent: 'lossless' },
     neteaseFmMode: normalizeFmMode(room.neteaseFmMode),
+    fmModeBeforeOff: normalizeFmMode(room.fmModeBeforeOff),
     announcementEnabled: Boolean(room.announcementEnabled),
     announcementText: String(room.announcementText || '').slice(0, MAX_ANNOUNCEMENT_LENGTH),
     chatHistoryVisibleOnJoin: Boolean(room.chatHistoryVisibleOnJoin),
@@ -257,6 +258,8 @@ function restoreRoomFromStorage(data) {
   room.userNicknames = new Map(Object.entries(data.userNicknames || {}));
   room.audioQuality = normalizeRoomAudioQuality(data.audioQuality);
   room.neteaseFmMode = normalizeFmMode(data.neteaseFmMode);
+  const fmModeBeforeOff = normalizeFmMode(data.fmModeBeforeOff);
+  room.fmModeBeforeOff = fmModeBeforeOff === FM_MODE_OFF ? DEFAULT_FM_MODE : fmModeBeforeOff;
   room.announcementEnabled = Boolean(data.announcementEnabled);
   room.announcementText = String(data.announcementText || '').slice(0, MAX_ANNOUNCEMENT_LENGTH);
   room.chatHistoryVisibleOnJoin = Boolean(data.chatHistoryVisibleOnJoin);
@@ -427,6 +430,7 @@ function createEmptyRoom(roomId, name, passwordHash = null) {
       tencent: 'lossless',
     },
     neteaseFmMode: DEFAULT_FM_MODE,
+    fmModeBeforeOff: DEFAULT_FM_MODE,
     announcementEnabled: false,
     announcementText: '',
     /** 进房是否可查看历史聊天；默认关闭（仅看进房后的消息） */
@@ -1264,6 +1268,10 @@ export function setRoomFmMode(roomId, actorId, mode, connectionId = null) {
     return { room: serializeRoom(room) };
   }
 
+  // 记住关闭前的模式，重新开启时恢复
+  if (nextMode === FM_MODE_OFF && room.neteaseFmMode !== FM_MODE_OFF) {
+    room.fmModeBeforeOff = normalizeFmMode(room.neteaseFmMode);
+  }
   room.neteaseFmMode = nextMode;
   clearNextRandom(room);
   persistRoom(room);
@@ -2174,6 +2182,11 @@ async function ensureNextRandom(room) {
     clearNextRandom(room);
     return;
   }
+  // 漫游已关闭：不预取，队列放空后自然停止
+  if ((room.neteaseFmMode || DEFAULT_FM_MODE) === FM_MODE_OFF) {
+    clearNextRandom(room);
+    return;
+  }
   if (room.nextRandom || room.nextRandomPromise) return;
 
   room.nextRandomPromise = (async () => {
@@ -2313,7 +2326,8 @@ async function playNextUnlocked(room, options = {}) {
   room.isPlaying = false;
   room.currentTime = 0;
   room.startedAt = null;
-  room.randomLoading = true;
+  // 漫游关闭时干净停机，不进入"漫游加载中"重试
+  room.randomLoading = (room.neteaseFmMode || DEFAULT_FM_MODE) !== FM_MODE_OFF;
   bumpPlaybackState(room);
 }
 
@@ -3212,6 +3226,7 @@ function serializeRoom(room, options = {}) {
     randomLoading: Boolean(room.randomLoading),
     audioQuality: normalizeRoomAudioQuality(room.audioQuality),
     neteaseFmMode: normalizeFmMode(room.neteaseFmMode),
+    fmModeBeforeOff: normalizeFmMode(room.fmModeBeforeOff),
     announcementEnabled: Boolean(room.announcementEnabled),
     announcementText: String(room.announcementText || '').slice(0, MAX_ANNOUNCEMENT_LENGTH),
     chatHistoryVisibleOnJoin: Boolean(room.chatHistoryVisibleOnJoin),
@@ -3264,6 +3279,7 @@ export function prepareRoomBroadcast(roomId) {
     randomLoading: Boolean(room.randomLoading),
     audioQuality: normalizeRoomAudioQuality(room.audioQuality),
     neteaseFmMode: normalizeFmMode(room.neteaseFmMode),
+    fmModeBeforeOff: normalizeFmMode(room.fmModeBeforeOff),
     announcementEnabled: Boolean(room.announcementEnabled),
     announcementText: String(room.announcementText || '').slice(0, MAX_ANNOUNCEMENT_LENGTH),
     chatHistoryVisibleOnJoin: Boolean(room.chatHistoryVisibleOnJoin),


### PR DESCRIPTION
房间设置漫游页顶部增加开关，关闭后队列放空即停止播放，不再自动推荐；
重新开启时恢复关闭前选择的漫游模式；
关闭状态下模式列表置灰
房间左上角漫游角标显示「已关闭」