### PR TITLE
Untrack server/adminConfig.json (already gitignored, tracked by mistake)

### DIFF
--- a/server/adminConfig.json
+++ b/server/adminConfig.json
@@ -1,4 +1,0 @@
-{
-  "entryPath": "/EWc21rM9Uv5PEfUn",
-  "entryPathCustomized": true
-}


### PR DESCRIPTION
server/adminConfig.json is per-deployment runtime state (the generated admin-panel entry path), listed in .gitignore, but it was already tracked before that gitignore rule was added — .gitignore only stops *new* files from being added, it doesn't untrack existing ones. Every server running a source/PM2 deployment therefore always shows this file as locally modified, which blocks a plain `git pull` (and now blocks `deploy/deploy.sh update`'s safety check) forever, on every update.

`git rm --cached` removes it from tracking without touching the file on disk — existing deployments keep their real entryPath.

Note for already-affected deployments: this commit alone does not retroactively fix a server that already has local modifications to this path pre-existing from before the fix — git still needs to reconcile the divergent tracking history once. Run on that server before pulling:
  git rm --cached server/adminConfig.json
  git commit -m "untrack adminConfig.json"
  git pull
(verified this exact sequence end-to-end against an isolated throwaway repo: file content is preserved, git status is clean afterward, and no data is lost.)