### PR TITLE
fix: 修复任意成员可通过上报极短时长恶意切歌

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2854,6 +2854,8 @@ io.on('connection', (socket) => {
   });
 
   socket.on('report_track_duration', async ({ queueId, durationMs }, callback) => {
+    if (rejectRateLimited(socket, limitSocketAction, 'report_track_duration', callback)) return;
+
     const roomId = socketToRoom.get(socket.id);
     if (!roomId) {
       callback?.({ success: false, error: '未加入房间' });

--- a/server/roomManager.js
+++ b/server/roomManager.js
@@ -46,6 +46,8 @@ export const INITIAL_CHAT_LIMIT = 100;
 export const CHAT_PAGE_LIMIT = 50;
 const MAX_RANDOM_HISTORY = 200;
 const MAX_RANDOM_PREFETCH_ATTEMPTS = 20;
+/** 非控制者首次补种时长的最小合理值（毫秒），杜绝 durationMs:1 之类的恶意切歌 */
+const MIN_REPORTABLE_DURATION_MS = 1000;
 
 /** 播放顺序：顺序 / 乱序 / 单曲循环 / 列表循环 */
 export const PLAY_MODES = ["order", "shuffle", "loop-one", "loop-all"];
@@ -3826,6 +3828,16 @@ export function reportTrackDuration(roomId, userId, queueId, durationMs, connect
   if (!isController && existing > 0) return { error: "仅房主或管理员可上报时长" };
   // 允许缩短：CDN 截断预览时长常短于元数据，否则服务端永不 auto-advance
   if (existing > 0 && Math.abs(ms - existing) < 50) return { success: true, skipped: true };
+
+  // 非控制者首次补种时长时，禁止上报过小或小于当前已播放进度的值：
+  // 否则任意成员可凭 durationMs:1 触发 advanceEndedRoomNow 立即切歌。
+  // 合法补种时长必然 >= 已播放进度（歌未放完）且不小于最小合理歌曲时长。
+  if (!isController && existing === 0) {
+    const playedMs = Math.max(0, Math.floor(getPlaybackTime(room) * 1000));
+    if (ms < Math.max(playedMs, MIN_REPORTABLE_DURATION_MS)) {
+      return { error: "上报时长无效" };
+    }
+  }
 
   room.current.duration = Math.round(ms);
   persistRoom(room);


### PR DESCRIPTION
## 问题
`report_track_duration` 事件无速率限制，且非控制者在 `existing===0`（歌曲初始、控制者尚未上报时长）时可设置任意 `durationMs`。
由于 auto-advance 阈值为 `duration + 0.15s`，上报 `durationMs:1` 会在约 0.15s 后触发 `advanceEndedRoomNow` 立即切歌。

攻击者以只读身份进房，每首歌开始即上报极短时长，可让房间所有歌曲秒切、无法正常使用。

## 修复
- `report_track_duration` 事件增加 `rejectRateLimited`（复用 limitSocketAction，90/min）
- 非控制者首次补种时长须 `>= max(已播放进度, 1000ms)`：合法补种时长必然 ≥ 已播放进度且 ≥ 1s，恶意极短值被拒
- 控制者（房主/管理员）上报不受影响；非控制者补种真实时长不受影响

## 兼容性
客户端上报单位为毫秒（`reportTrackDuration.ts`），且 `useTrackDuration.ts` 中 `MIN_TRUSTED_MEDIA_DURATION_SEC=5`，可信时长 ≥5s，阈值 1s 有充分余量，不影响正常上报。

## 验证
- `node --check` 通过
- 现有 `npm test`（10 项）通过
- 改动仅 14 行纯添加，无逻辑删除