### PR TITLE
feat: 完善播放模式切换按钮

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -24,6 +24,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@types/node": "^22.0.0",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
         "@types/react-window": "^1.8.8",
@@ -2239,15 +2240,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
-      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -4113,13 +4112,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@types/react-window": "^1.8.8",

--- a/client/src/components/MiniPlayer.tsx
+++ b/client/src/components/MiniPlayer.tsx
@@ -247,7 +247,7 @@ export default memo(function MiniPlayer({
               </Tooltip>
             )}
 
-            <PlayModeButton className="mineradio-ctrl-btn hidden h-8 w-8 sm:flex" iconClassName="h-4 w-4" />
+            <PlayModeButton className="mineradio-ctrl-btn h-10 w-10" iconClassName="h-4 w-4" />
           </div>
 
           <div className="control-cluster modes">
@@ -449,7 +449,8 @@ export default memo(function MiniPlayer({
           </Tooltip>
         )}
 
-        <PlayModeButton className="hidden h-8 w-8 sm:flex" iconClassName="h-4 w-4" />
+        <PlayModeButton className="h-10 w-10" iconClassName="h-4 w-4" />
+
         <VolumeControl compact className="flex-shrink-0" />
             <FavoriteButton song={current} className="w-8 h-8 text-netease-muted hover:text-rose-300" />
         {showDesktopLyrics && <DesktopLyricsPiP song={current} />}

--- a/client/src/components/PlayModeButton.tsx
+++ b/client/src/components/PlayModeButton.tsx
@@ -22,44 +22,54 @@ export default function PlayModeButton({
   const { setRoomPlayMode } = useSocket();
   const [busy, setBusy] = useState(false);
   const meta = PLAY_MODE_META[playMode];
+  const nextMode = nextPlayMode(playMode);
+  const nextMeta = PLAY_MODE_META[nextMode];
   const Icon = meta.Icon;
 
   const handleClick = useCallback(async () => {
     if (!canControl || busy) return;
-    const next = nextPlayMode(playMode);
     setBusy(true);
     try {
-      const res = await setRoomPlayMode(next);
+      const res = await setRoomPlayMode(nextMode);
       if (!res.success) {
         window.dispatchEvent(new CustomEvent('openmusic:visual-toast', {
           detail: { message: res.error || '切换失败', type: 'error' },
         }));
       } else {
         window.dispatchEvent(new CustomEvent('openmusic:visual-toast', {
-          detail: { message: PLAY_MODE_META[next].label, type: 'success' },
+          detail: { message: nextMeta.label, type: 'success' },
         }));
       }
+    } catch {
+      window.dispatchEvent(new CustomEvent('openmusic:visual-toast', {
+        detail: { message: '切换失败，请稍后重试', type: 'error' },
+      }));
     } finally {
       setBusy(false);
     }
-  }, [busy, canControl, playMode, setRoomPlayMode]);
+  }, [busy, canControl, nextMeta.label, nextMode, setRoomPlayMode]);
 
   const tip = canControl
-    ? meta.label
-    : `${meta.label}（仅房主/管理员可切换）`;
+    ? `当前：${meta.label}，点击切换为${nextMeta.label}`
+    : `当前：${meta.label}（仅房主或管理员可切换）`;
 
   return (
-    <Tooltip content={tip}>
+    <Tooltip content={tip} tapToShow={!canControl}>
       <button
         type="button"
         onClick={() => void handleClick()}
-        disabled={!canControl || busy}
-        className={`flex items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+        disabled={busy}
+        className={`inline-flex min-h-[40px] min-w-[40px] flex-shrink-0 items-center justify-center rounded-full transition-[color,background-color,opacity,transform] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-netease-red/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black disabled:cursor-wait disabled:opacity-50 ${
+          !canControl ? 'cursor-not-allowed opacity-50' : 'active:scale-95'
+        } ${
           playMode === 'order'
             ? 'text-netease-muted hover:bg-white/10 hover:text-white'
             : 'text-netease-red hover:bg-netease-red/15'
         } ${className}`}
         aria-label={tip}
+        aria-disabled={!canControl || busy}
+        aria-busy={busy}
+        data-play-mode={playMode}
       >
         <Icon className={iconClassName} />
       </button>

--- a/client/src/components/PlayerPage.tsx
+++ b/client/src/components/PlayerPage.tsx
@@ -221,7 +221,7 @@ export default memo(function PlayerPage({ onClose }: Props) {
           />
         </div>
 
-        <div className="relative flex items-center justify-center gap-8 sm:gap-10 2xl:gap-16">
+        <div className="relative flex items-center justify-center gap-3 sm:gap-10 2xl:gap-16">
 
           <VolumeControl
             compact
@@ -305,5 +305,4 @@ export default memo(function PlayerPage({ onClose }: Props) {
   );
 
 });
-
 

--- a/server/playMode.test.js
+++ b/server/playMode.test.js
@@ -1,0 +1,203 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PLAY_MODES,
+  DEFAULT_PLAY_MODE,
+  addUser,
+  adminDestroyRoom,
+  createRoom,
+  finishCurrentSong,
+  getRoom,
+  getRoomInternal,
+  normalizePlayMode,
+  prepareRoomBroadcast,
+  removeUser,
+  setRoomAdmin,
+  setRoomPlayMode,
+  skipSong,
+} from './roomManager.js';
+
+const OWNER_ID = 'owner_0001';
+const OWNER_CONNECTION = 'connection-owner';
+
+function makeSong(id, queueId = `queue-${id}`) {
+  return {
+    queueId,
+    id,
+    source: 'netease',
+    name: `歌曲 ${id}`,
+    artist: '测试歌手',
+    album: '测试专辑',
+    pic: '',
+    duration: 180_000,
+    requestedBy: '测试用户',
+    addedAt: Date.now(),
+    likedByIds: [],
+    dislikedByIds: [],
+  };
+}
+
+function createTestRoom(t) {
+  const created = createRoom({ name: '播放模式测试', creatorId: OWNER_ID });
+  assert.ok(created?.id);
+  const roomId = created.id;
+  const joined = addUser(roomId, OWNER_ID, '房主', { connectionId: OWNER_CONNECTION });
+  assert.equal(joined?.creatorId, OWNER_ID);
+
+  const room = getRoomInternal(roomId);
+  assert.ok(room);
+  room.neteaseFmMode = 'OFF';
+  room.nextRandom = null;
+  room.nextRandomPromise = null;
+  room.randomBatch = [];
+  t.after(() => adminDestroyRoom(roomId));
+
+  return { roomId, room };
+}
+
+function seedPlayback(room, currentId = 'a', queueIds = []) {
+  room.current = makeSong(currentId);
+  room.queue = queueIds.map((id) => makeSong(id));
+  room.isPlaying = true;
+  room.currentTime = 0;
+  room.startedAt = Date.now();
+  room.randomLoading = false;
+  room.nextRandom = null;
+  room.nextRandomPromise = null;
+  room.randomBatch = [];
+  room.lastRecycledQueueId = null;
+}
+
+test('播放模式使用固定五种顺序，未知值降级为顺序播放', () => {
+  assert.deepEqual(PLAY_MODES, [
+    'order',
+    'shuffle',
+    'loop-one',
+    'loop-all',
+    'shuffle-loop',
+  ]);
+  assert.equal(DEFAULT_PLAY_MODE, 'order');
+  assert.equal(normalizePlayMode('LOOP-ONE'), 'loop-one');
+  assert.equal(normalizePlayMode('legacy-mode'), 'order');
+  assert.equal(normalizePlayMode(null), 'order');
+});
+
+test('房主切换五种模式后，房间快照和广播状态保持一致', (t) => {
+  const { roomId } = createTestRoom(t);
+
+  for (const mode of PLAY_MODES) {
+    const result = setRoomPlayMode(roomId, OWNER_ID, mode, OWNER_CONNECTION);
+    assert.equal(result.error, undefined);
+    assert.equal(result.room?.playMode, mode);
+    assert.equal(getRoom(roomId)?.playMode, mode);
+    assert.equal(prepareRoomBroadcast(roomId)?.shared.playMode, mode);
+  }
+
+  const fallback = setRoomPlayMode(roomId, OWNER_ID, 'legacy-mode', OWNER_CONNECTION);
+  assert.equal(fallback.error, undefined);
+  assert.equal(fallback.room?.playMode, 'order');
+});
+
+test('仅房主、正式管理员和临时控播管理员可以切换模式', (t) => {
+  const { roomId } = createTestRoom(t);
+  const adminId = 'admin_0001';
+  const memberId = 'member_001';
+  const adminConnection = 'connection-admin';
+  const memberConnection = 'connection-member';
+
+  addUser(roomId, adminId, '管理员', { connectionId: adminConnection });
+  addUser(roomId, memberId, '成员', { connectionId: memberConnection });
+
+  const denied = setRoomPlayMode(roomId, memberId, 'shuffle', memberConnection);
+  assert.match(denied.error || '', /仅房主或管理员/);
+
+  const appointed = setRoomAdmin(roomId, OWNER_ID, adminId, true, OWNER_CONNECTION);
+  assert.equal(appointed.error, undefined);
+  assert.equal(setRoomPlayMode(roomId, adminId, 'shuffle', adminConnection).room?.playMode, 'shuffle');
+
+  removeUser(roomId, OWNER_ID, OWNER_CONNECTION);
+  removeUser(roomId, adminId, adminConnection);
+  const temporaryController = getRoom(roomId);
+  assert.equal(temporaryController?.ownerId, memberId);
+  assert.deepEqual(temporaryController?.autoPromotedAdminIds, [memberId]);
+  assert.equal(setRoomPlayMode(roomId, memberId, 'loop-one', memberConnection).room?.playMode, 'loop-one');
+});
+
+test('顺序播放自然结束后按队列顺序消费歌曲，空队列时停止', async (t) => {
+  const { roomId, room } = createTestRoom(t);
+  room.playMode = 'order';
+  seedPlayback(room, 'a', ['b', 'c']);
+
+  const advanced = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, room.current.queueId);
+  assert.equal(advanced.error, undefined);
+  assert.equal(advanced.room?.current?.id, 'b');
+  assert.deepEqual(advanced.room?.queue.map((song) => song.id), ['c']);
+
+  seedPlayback(room, 'only', []);
+  const stopped = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, room.current.queueId);
+  assert.equal(stopped.room?.current, null);
+  assert.equal(stopped.room?.isPlaying, false);
+  assert.deepEqual(stopped.room?.queue, []);
+});
+
+test('随机播放自然结束后随机选取并消费一首待播歌曲', async (t) => {
+  const { roomId, room } = createTestRoom(t);
+  room.playMode = 'shuffle';
+  seedPlayback(room, 'a', ['b', 'c', 'd']);
+
+  const advanced = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, room.current.queueId);
+  assert.equal(advanced.error, undefined);
+  assert.ok(['b', 'c', 'd'].includes(advanced.room?.current?.id));
+  assert.equal(advanced.room?.queue.length, 2);
+  assert.equal(advanced.room?.queue.some((song) => song.id === 'a'), false);
+});
+
+test('单曲循环只在自然结束时重播，手动切歌仍然前进', async (t) => {
+  const { roomId, room } = createTestRoom(t);
+  room.playMode = 'loop-one';
+  seedPlayback(room, 'a', ['b', 'c']);
+  const originalQueueId = room.current.queueId;
+
+  const replayed = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, originalQueueId);
+  assert.equal(replayed.error, undefined);
+  assert.equal(replayed.room?.current?.id, 'a');
+  assert.equal(replayed.room?.current?.queueId, originalQueueId);
+  assert.deepEqual(replayed.room?.queue.map((song) => song.id), ['b', 'c']);
+
+  const skipped = await skipSong(roomId, OWNER_ID, OWNER_CONNECTION);
+  assert.equal(skipped.error, undefined);
+  assert.equal(skipped.room?.current?.id, 'b');
+  assert.deepEqual(skipped.room?.queue.map((song) => song.id), ['c']);
+});
+
+test('列表循环会回收已播歌曲，并兼容只有一首歌的队列', async (t) => {
+  const { roomId, room } = createTestRoom(t);
+  room.playMode = 'loop-all';
+  seedPlayback(room, 'a', ['b', 'c']);
+
+  const advanced = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, room.current.queueId);
+  assert.equal(advanced.room?.current?.id, 'b');
+  assert.deepEqual(advanced.room?.queue.map((song) => song.id), ['c', 'a']);
+
+  seedPlayback(room, 'only', []);
+  const replayed = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, room.current.queueId);
+  assert.equal(replayed.room?.current?.id, 'only');
+  assert.deepEqual(replayed.room?.queue, []);
+});
+
+test('列表内随机会回收歌曲，多首时避免立即重复，单首时继续循环', async (t) => {
+  const { roomId, room } = createTestRoom(t);
+  room.playMode = 'shuffle-loop';
+  seedPlayback(room, 'a', ['b', 'c']);
+
+  const advanced = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, room.current.queueId);
+  assert.ok(['b', 'c'].includes(advanced.room?.current?.id));
+  assert.notEqual(advanced.room?.current?.id, 'a');
+  assert.equal(advanced.room?.queue.length, 2);
+  assert.equal(advanced.room?.queue.some((song) => song.id === 'a'), true);
+
+  seedPlayback(room, 'only', []);
+  const replayed = await finishCurrentSong(roomId, OWNER_ID, OWNER_CONNECTION, room.current.queueId);
+  assert.equal(replayed.room?.current?.id, 'only');
+  assert.deepEqual(replayed.room?.queue, []);
+});


### PR DESCRIPTION
## 功能说明

在播放控制区增加网易云音乐式的小图标按钮。每次点击按以下顺序切换：

1. 顺序播放
2. 随机播放
3. 单曲循环
4. 列表循环
5. 列表内随机

切换后会更新按钮图标、显示当前模式提示，并同步给房间内其他成员。

## 具体改动

- 完善共享播放模式按钮，增加当前模式、下一模式、提交中和失败提示
- 在完整播放器和迷你播放器中常驻展示按钮
- 窄屏下保留不小于 40×40px 的触控区域，避免控制区溢出
- 普通成员可以查看当前模式，但不能切换
- 房主、正式管理员和临时控播管理员沿用现有控播权限
- 继续使用 set_room_play_mode 事件和 RoomState.playMode 字段
- Android 通知栏继续通过 toggleMode 桥接使用相同的切换顺序
- 新增服务端播放模式回归测试

## 播放语义

- 顺序播放和随机播放会正常消费待播队列
- 单曲循环仅在歌曲自然结束时重播，手动切歌仍会前进
- 列表循环会将已播歌曲放回队列
- 列表内随机会回收已播歌曲，并尽量避免立即重复
- 未知或旧模式值会安全降级为顺序播放

## 验证结果

- 服务端测试：22 项全部通过
- TypeScript 类型检查：通过
- 前端生产构建：通过
- 320px 窄屏布局：无横向溢出
- 双浏览器房间广播、权限限制、刷新和重连恢复：通过
- Android 桥接权限与模式同步模拟：通过

## 兼容性

- 不修改公共协议
- 不需要配置、Redis 或数据迁移
- 服务端生产播放主链路未改动