### PR TITLE
Potential fix for code scanning alert no. 24: Type confusion through parameter tampering

### DIFF
--- a/server/wechatFileHelperProxy.js
+++ b/server/wechatFileHelperProxy.js
@@ -367,10 +367,12 @@ function readForwardBody(req) {
   if (req.method === 'GET' || req.method === 'HEAD') return undefined;
   if (Buffer.isBuffer(req.rawBody)) return req.rawBody;
   if (typeof req.rawBody === 'string') return req.rawBody;
+  if (Array.isArray(req.rawBody)) return undefined;
   if (req.body == null) return undefined;
   if (Buffer.isBuffer(req.body)) return req.body;
   if (typeof req.body === 'string') return req.body;
-  if (typeof req.body === 'object') return JSON.stringify(req.body);
+  if (Array.isArray(req.body)) return undefined;
+  if (Object.prototype.toString.call(req.body) === '[object Object]') return JSON.stringify(req.body);
   return undefined;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/qq01-hub/openmusic/security/code-scanning/24](https://github.com/qq01-hub/openmusic/security/code-scanning/24)

The best fix is to **validate and normalize request body types before forwarding**, and explicitly reject array payloads (or other unexpected runtime types) so attacker-controlled parameter shape cannot alter logic unexpectedly.

In `server/wechatFileHelperProxy.js`, update `readForwardBody(req)` so it:
- keeps current handling for `Buffer`, `string`, and plain object payloads,
- rejects arrays from `req.rawBody` / `req.body` by returning `undefined` (so no body is forwarded),
- only JSON-stringifies **plain objects** (not arrays or exotic objects).

This preserves existing functionality for standard payloads while removing type confusion paths from request-parameter tampering. No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
