### PR TITLE
fix: 修复 socket.io 传输降级失败导致连接中断

### DIFF
--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -84,6 +84,8 @@ function getSocket(): Socket {
 
       transports: ['websocket', 'polling'],
 
+      tryAllTransports: true,
+
       autoConnect: false,
 
       withCredentials: true,


### PR DESCRIPTION
当初始传输（websocket）连接失败、回退到其他传输（polling）时，客户端未启用 tryAllTransports 导致降级失败、连接中断。启用后自动尝试所有可用传输，保证弱网/受限网络下的连接稳定。