### PR TITLE
fix: 将 Socket.IO 心跳间隔调整为 10 秒，规避 CDN/代理 16 秒超时导致的长轮询 400 重连

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -347,7 +347,7 @@ const io = new Server(httpServer, {
   },
   httpCompression: true,
   // 人多时事件循环偶发阻塞，放宽 ping 超时减少误判断连
-  pingInterval: 25_000,
+  pingInterval: 10_000,
   pingTimeout: 60_000,
 });
 


### PR DESCRIPTION
## 变更内容

- `server/index.js`：将 Socket.IO 的 `pingInterval` 从 `25_000` 调整为 `10_000`。
- 心跳由 25 秒缩短到 10 秒，能在 CDN/代理约 16 秒的空闲超时前发出，避免长轮询 GET 返回空响应 400 导致客户端反复重连。
- 分支还包含此前已提交的 `tryAllTransports` 客户端降级修复，进一步保障弱网/受限网络下的连接稳定。

## 验证

- `node --check server/index.js` 通过
- `git diff --check` 通过
- 本地服务通过 `npm test --prefix server` 相关测试（未运行完整服务端测试）
